### PR TITLE
options to make threat detection settable + better log handling

### DIFF
--- a/r-mysql.tf
+++ b/r-mysql.tf
@@ -16,6 +16,15 @@ resource "azurerm_mysql_server" "mysql_server" {
   version                      = var.mysql_version
   ssl_enforcement_enabled      = var.force_ssl
 
+  threat_detection_policy {
+    enabled                    = var.tdp_enabled
+    disabled_alerts            = var.tdp_enabled ? var.tdp_disabled_alerts : null
+    email_account_admins       = var.tdp_enabled ? var.tdp_email_account_admins : null
+    email_addresses            = var.tdp_enabled ? var.tdp_email_addresses : null
+    retention_days             = var.tdp_enabled ? var.tdp_retention_days : null
+    storage_account_access_key = var.tdp_enabled ? var.tdp_storage_account_access_key : null
+    storage_endpoint           = var.tdp_enabled ? var.tdp_storage_endpoint : null
+  }
 
   tags = merge(local.default_tags, var.extra_tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,7 @@ variable "enable_user_suffix" {
 variable "logs_destinations_ids" {
   type        = list(string)
   description = "List of destination resources Ids for logs diagnostics destination. Can be Storage Account, Log Analytics Workspace and Event Hub. No more than one of each can be set. Empty list to disable logging."
+  default     = []
 }
 
 variable "logs_categories" {
@@ -174,4 +175,46 @@ variable "logs_retention_days" {
   type        = number
   description = "Number of days to keep logs on storage account"
   default     = 30
+}
+
+variable "tdp_enabled" {
+  description = "(Required) Threat detection policy enabled if set to true"
+#  type        = bool
+  default     = false
+}
+
+variable "tdp_disabled_alerts" {
+  description = "(Optional) We can disable specific alerts for the threat detection policy"
+  type        = list(string)
+  default     = []
+}
+
+variable "tdp_email_account_admins" {
+  description = "(Optional) Set to email the threat detection warnings to admins if true"
+  type        = bool
+  default     = false
+}
+
+variable "tdp_email_addresses" {
+  description = "(Optional) List of emails to send email to for threat detection warnings"
+  type        = list(string)
+  default     = []
+}
+
+variable "tdp_retention_days" {
+  description = "(Optional) Number of days to retain threats logged"
+  type        = number
+  default     = 0
+}
+
+variable "tdp_storage_account_access_key" {
+  description = "(Optional) Specifies the identifier key of the Threat Detection audit storage account."
+  type        = string
+  default     = null
+}
+
+variable "tdp_storage_endpoint" {
+  description = "(Optional) Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all Threat Detection audit logs."
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
I'd like to get this working so I stop getting false change detection

i.e. 

      + threat_detection_policy {
          + enabled = false
        }
        # (1 unchanged block hidden)


and a few other unrelated fixes.

Would also propose moving to an autodocumented README setup.